### PR TITLE
Add features: ErrorRedirectTo, RawBodyCodec

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Additionally, Registry can be generated for each request. For more details, plea
 * Query String: use the `query` struct tag
 * JSON (`application/json`): use the `json` struct tag
 * Form (`application/x-www-form-urlencoded`): use the `form` struct tag
+* Raw Body: use the `rawbody` struct tag with []byte or io.ReadCloser
+  * also support naked []byte or io.ReadCloser
 
 If you want to use other bindings, you can implement the `tanukirpc.Codec` interface and specify it using the `tanukirpc.WithCodec` option when initializing the router.
 
@@ -103,6 +105,26 @@ If you want to use custom validation, you can implement the `tanukirpc.Validatab
 ### Error handling
 
 `tanukirpc` has a default error handler. If you want to use custom error handling, you can implement the `tanukirpc.ErrorHooker` interface and use this with the `tanukirpc.WithErrorHooker` option when initializing the router.
+
+#### Response with Status Code
+
+If you want to return a response with a specific status code, you can use the `tanukirpc.WrapErrorWithStatus`.
+
+```go
+// this handler returns a 404 status code
+func notFoundHandler(ctx tanukirpc.Context[struct{}], struct{}) (*struct{}, error) {
+    return nil, tanukirpc.WrapErrorWithStatus(http.StatusNotFound, errors.New("not found"))
+}
+```
+
+Also, you can use the `tanukirpc.ErrorRedirectTo` function. This function returns a response with a 3xx status code and a `Location` header.
+
+```go
+// this handler returns a 301 status code
+func redirectHandler(ctx tanukirpc.Context[struct{}], struct{}) (*struct{}, error) {
+    return nil, tanukirpc.ErrorRedirectTo(http.StatusMovedPermanently, "/new-location")
+}
+```
 
 ### Middleware
 

--- a/error.go
+++ b/error.go
@@ -1,6 +1,8 @@
 package tanukirpc
 
 import (
+	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 )
@@ -31,6 +33,33 @@ func WrapErrorWithStatus(status int, err error) error {
 	return &errorWithStatus{status: status, err: err}
 }
 
+type ErrorWithRedirect interface {
+	error
+	Status() int
+	Redirect() string
+}
+
+type errorWithRedirect struct {
+	status   int
+	redirect string
+}
+
+func (e *errorWithRedirect) Error() string {
+	return fmt.Sprintf("redirect to %s", e.redirect)
+}
+
+func (e *errorWithRedirect) Status() int {
+	return e.status
+}
+
+func (e *errorWithRedirect) Redirect() string {
+	return e.redirect
+}
+
+func ErrorRedirectTo(status int, redirect string) error {
+	return &errorWithRedirect{status: status, redirect: redirect}
+}
+
 type ErrorMessage struct {
 	Error ErrorBody `json:"error"`
 }
@@ -46,7 +75,13 @@ type ErrorHooker interface {
 type errorHooker struct{}
 
 func (e *errorHooker) OnError(w http.ResponseWriter, req *http.Request, logger *slog.Logger, codec Codec, err error) {
-	if ews, ok := err.(ErrorWithStatus); ok {
+	var ewr ErrorWithRedirect
+	if errors.As(err, &ewr) {
+		http.Redirect(w, req, ewr.Redirect(), ewr.Status())
+		return
+	}
+	var ews ErrorWithStatus
+	if errors.As(err, &ews) {
 		w.WriteHeader(ews.Status())
 	} else {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/genclient/typescriptclient.tmpl
+++ b/genclient/typescriptclient.tmpl
@@ -116,7 +116,9 @@ type client = {
 {{- end }}
 };
 
-export const newClient = (baseURL = ""): client => {
+type myFetcher = (input: string, init: { method: string; headers: Record<string, string>; body: string | undefined; }) => Promise<Response>;
+
+export const newClient = (baseURL = "", myFetch: myFetcher = fetch): client => {
   const fetchByPath = async <PM extends keyof apiSchemaCollection>(method: method, path: string, args: pathCallArgs<PM>) => {
 {{- with .BuiltPaths }}
     const builtPath = hasApiPathBuilder(path) && hasApiPathArgs(args) ? pathBuilderByPath(path)(args.pathArgs) : path;
@@ -125,7 +127,7 @@ export const newClient = (baseURL = ""): client => {
 {{- end }}
     const query = hasApiQuery(args) ? `?${new URLSearchParams(args.query).toString()}` : "";
     const body = hasApiRequest(args) ? JSON.stringify(args.data) : undefined;
-    const response = await fetch(baseURL + builtPath + query, {
+    const response = await myFetch(baseURL + builtPath + query, {
       method,
       headers: {
         "Content-Type": "application/json",

--- a/handler.go
+++ b/handler.go
@@ -71,10 +71,12 @@ func (h *handler[Req, Res, Reg]) build(r *Router[Reg]) http.HandlerFunc {
 			lerr = err
 			return
 		}
-		if err := r.codec.Encode(ww, req, res); err != nil {
-			r.errorHooker.OnError(ww, req, r.logger, r.codec, err)
-			lerr = err
-			return
+		if ww.Status() == 0 {
+			if err := r.codec.Encode(ww, req, res); err != nil {
+				r.errorHooker.OnError(ww, req, r.logger, r.codec, err)
+				lerr = err
+				return
+			}
 		}
 		t2 = time.Now()
 

--- a/validator.go
+++ b/validator.go
@@ -62,7 +62,7 @@ func hasValidateTag(req any) bool {
 		if ftt.Kind() == reflect.Pointer {
 			ftt = ftt.Elem()
 		}
-		if ftt.Kind() == reflect.Struct {
+		if ftt.Kind() == reflect.Struct && ft.IsExported() {
 			if hasValidateTag(fv.Interface()) {
 				return true
 			}


### PR DESCRIPTION
## ErrorRedirectTo

You can use the `tanukirpc.ErrorRedirectTo` function. This function returns a response with a 3xx status code and a `Location` header.

```go
// this handler returns a 301 status code
func redirectHandler(ctx tanukirpc.Context[struct{}], struct{}) (*struct{}, error) {
    return nil, tanukirpc.ErrorRedirectTo(http.StatusMovedPermanently, "/new-location")
}
```

## RawBodyCodec

If you use the `rawbody` struct tag with []byte or io.ReadCloser, or naked []byte or io.ReadCloser, tanukirpc set request body that.

Also, you can response with raw []byte or io.Reader.

```go
type echoRequest struct {
    Body []byte `rawbody:"true"`
}

func echoHandler(ctx tanukirpc.Context[struct{}], req rawBodyRequest) ([]byte, error) {
    return req.Body, nil
}
```
