### PR TITLE
feat(context): add closer function to NewContextHookFactory for resource cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,29 @@ Registry injection is unique feature of `tanukirpc`. You can inject a registry o
 
 Additionally, Registry can be generated for each request. For more details, please refer to [_example/simple-registry](./_example/simple-registry).
 
+You can also define a cleanup function for the registry created by the factory. The `NewContextHookFactory` function accepts an optional `closer` function (`func(ctx Context[Reg]) error`). This function is automatically registered using `ctx.Defer` and executed after the handler finishes, making it suitable for releasing resources associated with the per-request registry.
+
+```go
+// Example: Define a closer function when creating the factory
+factory := tanukirpc.NewContextHookFactory(
+    func(w http.ResponseWriter, req *http.Request) (*MyRegistry, error) {
+        // ... create registry ...
+        dbConn, err := connectToDB() // Example: Get a DB connection
+        if err != nil {
+            return nil, err
+        }
+        registry := &MyRegistry{db: dbConn}
+        return registry, nil
+    },
+    func(ctx tanukirpc.Context[*MyRegistry]) error {
+        // This function will be called after the handler
+        registry := ctx.Registry()
+        return registry.db.Close() // Example: Close the DB connection
+    },
+)
+r := tanukirpc.NewRouterWithFactory(factory)
+```
+
 #### Use case
 
 * Database connection

--- a/context.go
+++ b/context.go
@@ -80,10 +80,14 @@ func (c *context[Reg]) DeferDo(timing DeferDoTiming) error {
 }
 
 type contextHookFactory[Reg any] struct {
-	fn func(w http.ResponseWriter, req *http.Request) (Reg, error)
+	fn     func(w http.ResponseWriter, req *http.Request) (Reg, error)
+	closer []func(ctx Context[Reg]) error
 }
 
-func NewContextHookFactory[Reg any](fn func(w http.ResponseWriter, req *http.Request) (Reg, error)) ContextFactory[Reg] {
+func NewContextHookFactory[Reg any](fn func(w http.ResponseWriter, req *http.Request) (Reg, error), closer ...func(ctx Context[Reg]) error) ContextFactory[Reg] {
+	if len(closer) > 0 {
+		return &contextHookFactory[Reg]{fn: fn, closer: closer}
+	}
 	return &contextHookFactory[Reg]{fn: fn}
 }
 
@@ -92,13 +96,19 @@ func (c *contextHookFactory[Reg]) Build(w http.ResponseWriter, req *http.Request
 	if err != nil {
 		return nil, err
 	}
-
-	return &context[Reg]{
+	ctx := &context[Reg]{
 		Context:  req.Context(),
 		req:      req,
 		res:      w,
 		registry: registry,
-	}, nil
+	}
+	for _, closer := range c.closer {
+		ctx.Defer(func() error {
+			return closer(ctx)
+		})
+	}
+
+	return ctx, nil
 }
 
 type Transformer[Reg1 any, Reg2 any] interface {

--- a/handler.go
+++ b/handler.go
@@ -71,6 +71,7 @@ func (h *handler[Req, Res, Reg]) build(r *Router[Reg]) http.HandlerFunc {
 			lerr = err
 			return
 		}
+
 		if ww.Status() == 0 {
 			if err := r.codec.Encode(ww, req, res); err != nil {
 				r.errorHooker.OnError(ww, req, r.logger, r.codec, err)


### PR DESCRIPTION
Adds an optional `closer` function parameter to `NewContextHookFactory`.
This allows registering cleanup logic (e.g., closing database connections)
that will be automatically executed via `ctx.Defer` after the handler finishes processing the request.

Also updates the README to document this new feature.