### PR TITLE
feat(router): enhance RouteWithTransformer with closers and correct defer execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This is a simple example of how to use `tanukirpc`.
 package main
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -58,18 +59,18 @@ func main() {
   - use `tanukiup` command
 - :o: Generate TypeScript client code
   - use `gentypescript` command
-- :o: defer hooks for cleanup
+- :o: defer hooks for cleanup (works correctly with Context Transformation)
 - :o: Session management
 - :o: Authentication flow
   - :o: OpenID Connect
 
-### Registry injection
+### Registry injection and Context Transformation
 
-Registry injection is unique feature of `tanukirpc`. You can inject a registry object to the handler function.
+Registry injection is a unique feature of `tanukirpc`. You can inject a registry object into the handler function via the `Context`.
 
-Additionally, Registry can be generated for each request. For more details, please refer to [_example/simple-registry](./_example/simple-registry).
+A `ContextFactory` can generate a `Context` (and its associated `Registry`) for each request. For more details, please refer to [_example/simple-registry](./_example/simple-registry).
 
-You can also define a cleanup function for the registry created by the factory. The `NewContextHookFactory` function accepts an optional `closer` function (`func(ctx Context[Reg]) error`). This function is automatically registered using `ctx.Defer` and executed after the handler finishes, making it suitable for releasing resources associated with the per-request registry.
+You can define a cleanup function for the registry created by the factory. The `NewContextHookFactory` function accepts an optional `closer` function (`func(ctx Context[Reg]) error`). This function is automatically registered using `ctx.Defer` and executed after the handler finishes, making it suitable for releasing resources associated with the per-request registry.
 
 ```go
 // Example: Define a closer function when creating the factory
@@ -89,14 +90,53 @@ factory := tanukirpc.NewContextHookFactory(
         return registry.db.Close() // Example: Close the DB connection
     },
 )
-r := tanukirpc.NewRouterWithFactory(factory)
+// Use WithContextFactory option
+r := tanukirpc.NewRouter(struct{}{}, tanukirpc.WithContextFactory(factory))
+```
+
+Furthermore, `tanukirpc` allows composing contexts using `RouteWithTransformer`. This function takes an existing router (`*Router[Reg1]`), a `Transformer[Reg1, Reg2]`, a route pattern, and a function to define routes within the transformed context (`func(r *Router[Reg2])`). It also accepts optional `closer` functions (`func(ctx Context[Reg2]) error`) specific to the transformed context.
+
+This enables creating nested routing structures where inner routes operate with a different registry (`Reg2`) derived from the outer registry (`Reg1`). The transformer defines how to get `Reg2` from `Context[Reg1]`. Importantly, `Defer` calls registered in the outer context (`Context[Reg1]`) are correctly executed even when the request is handled within the inner, transformed context (`Context[Reg2]`). The `closer` functions provided to `RouteWithTransformer` are executed after the inner handlers complete, allowing for resource cleanup specific to the transformed context.
+
+```go
+// Example: Using RouteWithTransformer
+type OuterRegistry struct { /* ... */ }
+type InnerRegistry struct { /* ... derived from OuterRegistry */ }
+
+// Define how to transform OuterRegistry context to InnerRegistry
+transformer := tanukirpc.NewTransformer(func(ctx tanukirpc.Context[*OuterRegistry]) (*InnerRegistry, error) {
+    // ... logic to create InnerRegistry from ctx.Registry() ...
+    innerReg := &InnerRegistry{ /* ... */ }
+    // Register a defer function in the *outer* context if needed
+    ctx.Defer(func() error { fmt.Println("Outer context defer"); return nil })
+    return innerReg, nil
+})
+
+// Define a closer for the inner context
+innerCloser := func(ctx tanukirpc.Context[*InnerRegistry]) error {
+    fmt.Println("Closing inner context resources")
+    // ... cleanup for InnerRegistry ...
+    return nil
+}
+
+outerRouter := tanukirpc.NewRouter(&OuterRegistry{})
+
+// Create nested routes with a transformed context
+tanukirpc.RouteWithTransformer(outerRouter, transformer, "/inner", func(innerRouter *tanukirpc.Router[*InnerRegistry]) {
+    innerRouter.Get("/data", tanukirpc.NewHandler(func(ctx tanukirpc.Context[*InnerRegistry], req struct{}) (*struct{}, error) {
+        // Handler uses InnerRegistry via ctx.Registry()
+        ctx.Defer(func() error { fmt.Println("Inner context defer"); return nil }) // Defer in inner context
+        fmt.Println("Handling request with inner context")
+        return &struct{}{}, nil
+    }))
+}, innerCloser) // Pass the closer for the inner context
 ```
 
 #### Use case
 
-* Database connection
-* Logger
-* Authentication information
+* Database connection management (per-request or shared)
+* Logger configuration per route group
+* Authentication/Authorization context layering
 * Resource binding by path parameter. Examples can be found in [_example/todo](./_example/todo).
 
 ### Request binding
@@ -198,14 +238,32 @@ For more detailed usage, refer to the [_example/todo](./_example/todo) directory
 
 ### Defer hooks
 
-`tanukirpc` supports defer hooks for cleanup. You can register a function to be called after the handler function has been executed.
+`tanukirpc` supports defer hooks for cleanup. You can register a function using `ctx.Defer` to be called after the handler function has been executed. These hooks are executed in LIFO (Last-In, First-Out) order.
+
+`Defer` supports two timings:
+*   `DeferDoTimingAfterResponse` (default): Executes after the response has been written. Suitable for cleanup tasks like closing connections or logging.
+*   `DeferDoTimingBeforeResponse`: Executes before the response is written. Useful for modifying headers or performing actions just before sending the response.
+
+Deferred functions work correctly even when using `RouteWithTransformer`. Functions deferred in an outer context will execute after functions deferred in an inner context (respecting LIFO order across context boundaries).
 
 ```go
-func (ctx *tanukirpc.Context[struct{}], struct{}) (*struct{}, error) {
+func myHandler(ctx tanukirpc.Context[struct{}], req myRequest) (*myResponse, error) {
+    // This will run after the response is sent (default)
     ctx.Defer(func() error {
+        fmt.Println("Cleanup after response")
         // Close the database connection, release resources, logging, enqueue job etc...
+        return nil
     })
-    return &struct{}{}, nil
+
+    // This will run just before the response is sent
+    ctx.Defer(func() error {
+        fmt.Println("Action before response")
+        ctx.Response().Header().Set("X-Custom-Header", "value")
+        return nil
+    }, tanukirpc.DeferDoTimingBeforeResponse)
+
+    fmt.Println("Handler logic executing...")
+    return &myResponse{Data: "Success"}, nil
 }
 ```
 

--- a/context.go
+++ b/context.go
@@ -127,19 +127,46 @@ func (t *transformer[Reg1, Reg2]) Transform(ctx Context[Reg1]) (Reg2, error) {
 	return t.fn(ctx)
 }
 
-func compositionContextHooker[Reg1 any, Reg2 any](factory ContextFactory[Reg1], transformer Transformer[Reg1, Reg2]) ContextFactory[Reg2] {
-	return NewContextHookFactory(func(w http.ResponseWriter, req *http.Request) (Reg2, error) {
-		var zeroReg2 Reg2
-		ctx1, err := factory.Build(w, req)
-		if err != nil {
-			return zeroReg2, err
-		}
-		reg2, err := transformer.Transform(ctx1)
-		if err != nil {
-			return zeroReg2, err
-		}
-		return reg2, nil
-	})
+func compositionContextHooker[Reg1 any, Reg2 any](factory ContextFactory[Reg1], transformer Transformer[Reg1, Reg2], closer ...func(ctx Context[Reg2]) error) ContextFactory[Reg2] {
+	return &transformerContextHookFactory[Reg1, Reg2]{transformer: transformer, factory: factory, closer: closer}
+}
+
+type transformerContextHookFactory[Reg1 any, Reg2 any] struct {
+	transformer Transformer[Reg1, Reg2]
+	factory     ContextFactory[Reg1]
+	closer      []func(ctx Context[Reg2]) error
+}
+
+func (c *transformerContextHookFactory[Reg1, Reg2]) Build(w http.ResponseWriter, req *http.Request) (Context[Reg2], error) {
+	ctx1, err := c.factory.Build(w, req)
+	if err != nil {
+		return nil, err
+	}
+	reg2, err := c.transformer.Transform(ctx1)
+	if err != nil {
+		return nil, err
+	}
+	ctx2 := &context[Reg2]{
+		Context:  req.Context(),
+		req:      req,
+		res:      w,
+		registry: reg2,
+	}
+	ctx2.Defer(
+		func() error { return ctx1.DeferDo(DeferDoTimingBeforeResponse) },
+		DeferDoTimingBeforeResponse,
+	)
+	ctx2.Defer(
+		func() error { return ctx1.DeferDo(DeferDoTimingAfterResponse) },
+		DeferDoTimingAfterResponse,
+	)
+	for _, closer := range c.closer {
+		ctx2.Defer(func() error {
+			return closer(ctx2)
+		})
+	}
+
+	return ctx2, nil
 }
 
 type DeferFunc func() error

--- a/genclient/gendoc.go
+++ b/genclient/gendoc.go
@@ -342,7 +342,7 @@ func (i *instrs) tryRouteWithTransformer(pass *analysis.Pass, instr ssa.Instruct
 		return nil
 	}
 	args := call.Call.Args
-	if len(args) != 4 {
+	if len(args) != 5 {
 		pass.Reportf(call.Pos(), "invalid number of arguments")
 		return nil
 	}

--- a/router.go
+++ b/router.go
@@ -136,9 +136,9 @@ func (r *Router[Reg]) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	r.cr.ServeHTTP(w, req)
 }
 
-func RouteWithTransformer[Reg1 any, Reg2 any](r *Router[Reg1], tr Transformer[Reg1, Reg2], pattern string, fn func(r *Router[Reg2])) *Router[Reg1] {
+func RouteWithTransformer[Reg1 any, Reg2 any](r *Router[Reg1], tr Transformer[Reg1, Reg2], pattern string, fn func(r *Router[Reg2]), closer ...func(Context[Reg2]) error) *Router[Reg1] {
 	return r.Route(pattern, func(r *Router[Reg1]) {
-		cf := compositionContextHooker(r.contextFactory, tr)
+		cf := compositionContextHooker(r.contextFactory, tr, closer...)
 		r2 := &Router[Reg2]{
 			cr:             r.cr,
 			codec:          r.codec,


### PR DESCRIPTION
A RouteWithTransformer, allowing resource cleanup specific to the nested context.
Ensures deferred functions registered in outer contexts are correctly executed after inner context handlers and closers complete.
Updates documentation and examples to reflect the new capabilities.
Fixes the gentypescript analyzer to correctly parse the updated RouteWithTransformer signature.