### PR TITLE
feat(context): execute defers on error with DeferDoTimingBeforeCheckError

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,8 +240,9 @@ For more detailed usage, refer to the [_example/todo](./_example/todo) directory
 
 `tanukirpc` supports defer hooks for cleanup. You can register a function using `ctx.Defer` to be called after the handler function has been executed. These hooks are executed in LIFO (Last-In, First-Out) order.
 
-`Defer` supports two timings:
+`Defer` supports three timings:
 *   `DeferDoTimingAfterResponse` (default): Executes after the response has been written. Suitable for cleanup tasks like closing connections or logging.
+*   `DeferDoTimingBeforeCheckError`: Executes before checking if the response is an error. This timing is useful for actions that should occur regardless of whether the response is an error, such as logging or cleanup tasks. It will run even if the handler returns an error using `tanukirpc.WrapErrorWithStatus`, unlike the other timings.
 *   `DeferDoTimingBeforeResponse`: Executes before the response is written. Useful for modifying headers or performing actions just before sending the response.
 
 Deferred functions work correctly even when using `RouteWithTransformer`. Functions deferred in an outer context will execute after functions deferred in an inner context (respecting LIFO order across context boundaries).
@@ -264,6 +265,17 @@ func myHandler(ctx tanukirpc.Context[struct{}], req myRequest) (*myResponse, err
 
     fmt.Println("Handler logic executing...")
     return &myResponse{Data: "Success"}, nil
+}
+
+fnc myErrorHandler(ctx tanukirpc.Context[struct{}], req myRequest) (*myResponse, error) {
+    // This will run before checking if the response is an error
+    ctx.Defer(func() error {
+        fmt.Println("Cleanup before checking error")
+        return nil
+    }, tanukirpc.DeferDoTimingBeforeCheckError)
+
+    // Simulate an error
+    return nil, tanukirpc.WrapErrorWithStatus(http.StatusInternalServerError, errors.New("something went wrong"))
 }
 ```
 

--- a/context.go
+++ b/context.go
@@ -153,6 +153,10 @@ func (c *transformerContextHookFactory[Reg1, Reg2]) Build(w http.ResponseWriter,
 		registry: reg2,
 	}
 	ctx2.Defer(
+		func() error { return ctx1.DeferDo(DeferDoTimingBeforeCheckError) },
+		DeferDoTimingBeforeCheckError,
+	)
+	ctx2.Defer(
 		func() error { return ctx1.DeferDo(DeferDoTimingBeforeResponse) },
 		DeferDoTimingBeforeResponse,
 	)
@@ -163,7 +167,7 @@ func (c *transformerContextHookFactory[Reg1, Reg2]) Build(w http.ResponseWriter,
 	for _, closer := range c.closer {
 		ctx2.Defer(func() error {
 			return closer(ctx2)
-		})
+		}, DeferDoTimingBeforeCheckError)
 	}
 
 	return ctx2, nil
@@ -222,6 +226,7 @@ type DeferDoTiming int
 const (
 	DeferDoTimingBeforeResponse DeferDoTiming = iota
 	DeferDoTimingAfterResponse
+	DeferDoTimingBeforeCheckError
 )
 
 type deferStackMap map[DeferDoTiming]*deferStack

--- a/handler.go
+++ b/handler.go
@@ -60,6 +60,12 @@ func (h *handler[Req, Res, Reg]) build(r *Router[Reg]) http.HandlerFunc {
 		}
 
 		res, err := h.h(ctx, reqBody)
+		if err := ctx.DeferDo(DeferDoTimingBeforeCheckError); err != nil {
+			r.errorHooker.OnError(ww, req, r.logger, r.codec, err)
+			lerr = err
+			return
+		}
+		slog.InfoContext(ctx, "request completed")
 		if err != nil {
 			r.errorHooker.OnError(ww, req, r.logger, r.codec, err)
 			lerr = err

--- a/router_test.go
+++ b/router_test.go
@@ -72,6 +72,12 @@ func TestRouter(t *testing.T) {
 			expect:  deferDoHandlerExpect(store),
 		},
 		{
+			name:    "defer do on error handler",
+			router:  newDeferDoOnErrorHandler(store),
+			request: newDeferDoOnErrorHandlerRequest(t),
+			expect:  deferDoOnErrorHandlerExpect(store),
+		},
+		{
 			name:    "raw body codec handler",
 			router:  rawBodyCodecHandler(),
 			request: rawBodyCodecHandlerRequest(t),
@@ -246,6 +252,45 @@ func deferDoHandlerExpect(store map[string]string) func(t *testing.T, resp *http
 
 		assert.Equal(t, "ok", store["beforeResponseDefer"])
 		assert.Equal(t, "okok", store["afterResponseDefer"])
+	}
+}
+
+func newDeferDoOnErrorHandler(store map[string]string) http.Handler {
+	type deferDoResponse struct {
+		Ok bool `json:"ok"`
+	}
+	deferDoOnError := func(ctx tanukirpc.Context[struct{}], req struct{}) (*deferDoResponse, error) {
+		ctx.Defer(func() error {
+			store["beforeCheckError"] = "ok"
+			return nil
+		}, tanukirpc.DeferDoTimingBeforeCheckError)
+		return nil, tanukirpc.WrapErrorWithStatus(http.StatusNotFound, errors.New("not found"))
+	}
+	router := tanukirpc.NewRouter(struct{}{})
+	router.Use(middleware.Logger)
+	router.Get("/defer_on_error", tanukirpc.NewHandler(deferDoOnError))
+
+	return router
+}
+
+func newDeferDoOnErrorHandlerRequest(t *testing.T) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, "/defer_on_error", nil)
+	require.NoError(t, err)
+	req.Header.Set("accept", "application/json")
+	return req
+}
+
+func deferDoOnErrorHandlerExpect(store map[string]string) func(t *testing.T, resp *http.Response, err error) {
+	return func(t *testing.T, resp *http.Response, err error) {
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+		var body tanukirpc.ErrorMessage
+		assert.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+		assert.Equal(t, "not found", body.Error.Message)
+
+		assert.Equal(t, "ok", store["beforeCheckError"])
 	}
 }
 


### PR DESCRIPTION
Introduce a new defer timing, DeferDoTimingBeforeCheckError, to tanukirpc.Context. This ensures that registered defers can be executed even if an error occurs during handler execution, before error checking and response processing. Includes test coverage for error scenarios invoking this timing.