### PR TITLE
Fix tanukiup process cleanup on restart

### DIFF
--- a/tanukiup/command.go
+++ b/tanukiup/command.go
@@ -38,22 +38,39 @@ func runCommand(ctx context.Context, cmd *exec.Cmd) error {
 	terminateErr := terminateCommand(cmd)
 	timer := time.NewTimer(processShutdownGracePeriod)
 	defer timer.Stop()
+	ticker := time.NewTicker(20 * time.Millisecond)
+	defer ticker.Stop()
 
+	childDone := false
 	select {
 	case <-done:
-		// The direct child may have exited while descendants in its process group
-		// are still alive. Make a final best-effort sweep of the group.
-		_ = killCommand(cmd)
-		if terminateErr != nil && !errors.Is(terminateErr, os.ErrProcessDone) {
-			return terminateErr
+		childDone = true
+	default:
+	}
+	if terminateErr != nil && !errors.Is(terminateErr, os.ErrProcessDone) {
+		if !childDone {
+			<-done
 		}
-		return ctx.Err()
-	case <-timer.C:
-		killErr := killCommand(cmd)
-		<-done
-		if killErr != nil && !errors.Is(killErr, os.ErrProcessDone) {
-			return killErr
+		return terminateErr
+	}
+
+	for {
+		if childDone && commandGroupDone(cmd) {
+			return ctx.Err()
 		}
-		return ctx.Err()
+		select {
+		case <-done:
+			childDone = true
+		case <-ticker.C:
+		case <-timer.C:
+			killErr := killCommand(cmd)
+			if !childDone {
+				<-done
+			}
+			if killErr != nil && !errors.Is(killErr, os.ErrProcessDone) {
+				return killErr
+			}
+			return ctx.Err()
+		}
 	}
 }

--- a/tanukiup/command.go
+++ b/tanukiup/command.go
@@ -1,0 +1,65 @@
+package tanukiup
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"time"
+)
+
+const processShutdownGracePeriod = 5 * time.Second
+
+func newCommand(name string, arg ...string) *exec.Cmd {
+	cmd := exec.Command(name, arg...)
+	configureCommand(cmd)
+	return cmd
+}
+
+func runCommand(ctx context.Context, cmd *exec.Cmd) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+	}
+
+	terminateErr := terminateCommand(cmd)
+	timer := time.NewTimer(processShutdownGracePeriod)
+	defer timer.Stop()
+
+	select {
+	case err := <-done:
+		// The direct child may have exited while descendants in its process group
+		// are still alive. Make a final best-effort sweep of the group.
+		_ = killCommand(cmd)
+		if err != nil {
+			return err
+		}
+		if terminateErr != nil && !errors.Is(terminateErr, os.ErrProcessDone) {
+			return terminateErr
+		}
+		return ctx.Err()
+	case <-timer.C:
+		killErr := killCommand(cmd)
+		err := <-done
+		if err != nil {
+			return err
+		}
+		if killErr != nil && !errors.Is(killErr, os.ErrProcessDone) {
+			return killErr
+		}
+		return ctx.Err()
+	}
+}

--- a/tanukiup/command.go
+++ b/tanukiup/command.go
@@ -40,23 +40,17 @@ func runCommand(ctx context.Context, cmd *exec.Cmd) error {
 	defer timer.Stop()
 
 	select {
-	case err := <-done:
+	case <-done:
 		// The direct child may have exited while descendants in its process group
 		// are still alive. Make a final best-effort sweep of the group.
 		_ = killCommand(cmd)
-		if err != nil {
-			return err
-		}
 		if terminateErr != nil && !errors.Is(terminateErr, os.ErrProcessDone) {
 			return terminateErr
 		}
 		return ctx.Err()
 	case <-timer.C:
 		killErr := killCommand(cmd)
-		err := <-done
-		if err != nil {
-			return err
-		}
+		<-done
 		if killErr != nil && !errors.Is(killErr, os.ErrProcessDone) {
 			return killErr
 		}

--- a/tanukiup/command_other.go
+++ b/tanukiup/command_other.go
@@ -19,3 +19,7 @@ func killCommand(cmd *exec.Cmd) error {
 	}
 	return cmd.Process.Kill()
 }
+
+func commandGroupDone(cmd *exec.Cmd) bool {
+	return true
+}

--- a/tanukiup/command_other.go
+++ b/tanukiup/command_other.go
@@ -1,0 +1,21 @@
+//go:build !unix
+
+package tanukiup
+
+import (
+	"os"
+	"os/exec"
+)
+
+func configureCommand(cmd *exec.Cmd) {}
+
+func terminateCommand(cmd *exec.Cmd) error {
+	return killCommand(cmd)
+}
+
+func killCommand(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return os.ErrProcessDone
+	}
+	return cmd.Process.Kill()
+}

--- a/tanukiup/command_unix.go
+++ b/tanukiup/command_unix.go
@@ -1,0 +1,35 @@
+//go:build unix
+
+package tanukiup
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func configureCommand(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+func terminateCommand(cmd *exec.Cmd) error {
+	return signalCommandGroup(cmd, syscall.SIGTERM)
+}
+
+func killCommand(cmd *exec.Cmd) error {
+	return signalCommandGroup(cmd, syscall.SIGKILL)
+}
+
+func signalCommandGroup(cmd *exec.Cmd, sig syscall.Signal) error {
+	if cmd.Process == nil {
+		return os.ErrProcessDone
+	}
+	if err := syscall.Kill(-cmd.Process.Pid, sig); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return os.ErrProcessDone
+		}
+		return err
+	}
+	return nil
+}

--- a/tanukiup/command_unix.go
+++ b/tanukiup/command_unix.go
@@ -21,6 +21,16 @@ func killCommand(cmd *exec.Cmd) error {
 	return signalCommandGroup(cmd, syscall.SIGKILL)
 }
 
+func commandGroupDone(cmd *exec.Cmd) bool {
+	if cmd.Process == nil {
+		return true
+	}
+	if err := syscall.Kill(-cmd.Process.Pid, 0); err != nil {
+		return errors.Is(err, syscall.ESRCH)
+	}
+	return false
+}
+
 func signalCommandGroup(cmd *exec.Cmd, sig syscall.Signal) error {
 	if cmd.Process == nil {
 		return os.ErrProcessDone

--- a/tanukiup/tanukiup.go
+++ b/tanukiup/tanukiup.go
@@ -165,47 +165,51 @@ func Run(ctx context.Context, options ...Option) error {
 	}
 	defer watcher.Close()
 
-	errChan := make(chan error)
-	defer close(errChan)
 	restartChan := make(chan struct{})
 	defer close(restartChan)
 	go func() {
-		skipStart := false
-		for {
+		var (
+			commandDone  <-chan error
+			cancelRunner context.CancelFunc
+		)
+		startRunner := func() {
 			cmdCtx, cancel := context.WithCancel(ctx)
-			if !skipStart {
-				go func() {
-					if err := runGenerator(ctx); err != nil {
-						var exitError *exec.ExitError
-						if !errors.Is(err, context.Canceled) &&
-							!errors.As(err, &exitError) &&
-							exitError.ExitCode() != -1 {
-							slog.ErrorContext(ctx, "failed to generate command", slog.Any("error", err))
-							errChan <- err
-						}
-						return
-					}
-					if err := startCmd(cmdCtx, args); err != nil {
-						var exitError *exec.ExitError
-						if !errors.Is(err, context.Canceled) &&
-							!errors.As(err, &exitError) &&
-							exitError.ExitCode() != -1 {
-							slog.ErrorContext(ctx, "failed to start command", slog.Any("error", err))
-							errChan <- err
-						}
-					}
-				}()
+			done := make(chan error, 1)
+			commandDone = done
+			cancelRunner = cancel
+			go func() {
+				done <- runCommandCycle(cmdCtx, args)
+			}()
+		}
+		stopRunner := func() {
+			if cancelRunner == nil {
+				return
 			}
+			cancelRunner()
+			if err := <-commandDone; err != nil && !isCommandCancelError(err) {
+				slog.ErrorContext(ctx, "failed to stop command", slog.Any("error", err))
+			}
+			cancelRunner = nil
+			commandDone = nil
+		}
+		startRunner()
+		for {
 			select {
 			case <-ctx.Done():
-				cancel()
+				stopRunner()
 				return
 			case <-restartChan:
-				cancel()
-				skipStart = false
-			case <-errChan:
-				cancel()
-				skipStart = true
+				stopRunner()
+				startRunner()
+			case err := <-commandDone:
+				if cancelRunner != nil {
+					cancelRunner()
+				}
+				cancelRunner = nil
+				commandDone = nil
+				if err != nil && !isCommandCancelError(err) {
+					slog.ErrorContext(ctx, "command stopped with error", slog.Any("error", err))
+				}
 			}
 		}
 	}()
@@ -271,6 +275,27 @@ func Run(ctx context.Context, options ...Option) error {
 	return nil
 }
 
+func runCommandCycle(ctx context.Context, args *optionArgs) error {
+	if err := runGenerator(ctx); err != nil {
+		return fmt.Errorf("failed to generate command: %w", err)
+	}
+	if err := startCmd(ctx, args); err != nil {
+		return fmt.Errorf("failed to start command: %w", err)
+	}
+	return nil
+}
+
+func isCommandCancelError(err error) bool {
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, context.Canceled) {
+		return true
+	}
+	var exitError *exec.ExitError
+	return errors.As(err, &exitError) && exitError.ExitCode() == -1
+}
+
 type isDirer interface {
 	IsDir() bool
 }
@@ -326,11 +351,11 @@ func startCmd(ctx context.Context, args *optionArgs) error {
 		}
 	}
 	slog.InfoContext(ctx, "building command", slog.Any("command", buildCommand))
-	bcmd := exec.CommandContext(ctx, buildCommand[0], buildCommand[1:]...)
+	bcmd := newCommand(buildCommand[0], buildCommand[1:]...)
 	bcmd.Dir = args.baseDir
 	bcmd.Stdout = os.Stdout
 	bcmd.Stderr = os.Stderr
-	if err := bcmd.Run(); err != nil {
+	if err := runCommand(ctx, bcmd); err != nil {
 		return fmt.Errorf("failed to build command: %w", err)
 	}
 	defer os.Remove(outpath)
@@ -345,7 +370,7 @@ func startCmd(ctx context.Context, args *optionArgs) error {
 	}
 
 	slog.InfoContext(ctx, "executing command", slog.Any("command", execCommand))
-	ecmd := exec.CommandContext(ctx, execCommand[0], execCommand[1:]...)
+	ecmd := newCommand(execCommand[0], execCommand[1:]...)
 	ecmd.Dir = args.baseDir
 	ecmd.Stdout = os.Stdout
 	ecmd.Stderr = os.Stderr
@@ -355,7 +380,7 @@ func startCmd(ctx context.Context, args *optionArgs) error {
 		waitAndListenProxyServer(ctx, args.addr, args.handlerDir, up, args.catchAllTarget)
 	}
 
-	if err := ecmd.Run(); err != nil {
+	if err := runCommand(ctx, ecmd); err != nil {
 		return fmt.Errorf("failed to start command: %w", err)
 	}
 
@@ -369,11 +394,11 @@ type generatorInfo struct {
 
 func (g *generatorInfo) run(ctx context.Context) error {
 	slog.InfoContext(ctx, "running generator", slog.Any("command", g.command), slog.String("dir", g.dir))
-	cmd := exec.CommandContext(ctx, g.command[0], g.command[1:]...)
+	cmd := newCommand(g.command[0], g.command[1:]...)
 	cmd.Dir = g.dir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
+	if err := runCommand(ctx, cmd); err != nil {
 		return fmt.Errorf("failed to run generator: %w", err)
 	}
 	return nil
@@ -447,10 +472,10 @@ var routePathsCommand = []string{"go", "run", "github.com/mackee/tanukirpc/cmd/s
 
 func retrievePaths(ctx context.Context, handlerDir string) ([]routePath, error) {
 	buf := &bytes.Buffer{}
-	ecmd := exec.CommandContext(ctx, routePathsCommand[0], append(routePathsCommand[1:], handlerDir)...)
+	ecmd := newCommand(routePathsCommand[0], append(routePathsCommand[1:], handlerDir)...)
 	ecmd.Stdout = buf
 
-	if err := ecmd.Run(); err != nil {
+	if err := runCommand(ctx, ecmd); err != nil {
 		return nil, fmt.Errorf("failed to run showpaths: %w", err)
 	}
 	type paths struct {

--- a/tanukiup/tanukiup.go
+++ b/tanukiup/tanukiup.go
@@ -166,8 +166,9 @@ func Run(ctx context.Context, options ...Option) error {
 	defer watcher.Close()
 
 	restartChan := make(chan struct{}, 1)
-	defer close(restartChan)
+	runnerDone := make(chan struct{})
 	go func() {
+		defer close(runnerDone)
 		var (
 			commandDone  <-chan error
 			cancelRunner context.CancelFunc
@@ -275,6 +276,7 @@ func Run(ctx context.Context, options ...Option) error {
 	}
 
 	<-ctx.Done()
+	<-runnerDone
 	return nil
 }
 

--- a/tanukiup/tanukiup.go
+++ b/tanukiup/tanukiup.go
@@ -165,7 +165,7 @@ func Run(ctx context.Context, options ...Option) error {
 	}
 	defer watcher.Close()
 
-	restartChan := make(chan struct{})
+	restartChan := make(chan struct{}, 1)
 	defer close(restartChan)
 	go func() {
 		var (
@@ -233,7 +233,10 @@ func Run(ctx context.Context, options ...Option) error {
 						continue
 					}
 					slog.InfoContext(ctx, "modified file", slog.String("filename", event.Name))
-					restartChan <- struct{}{}
+					select {
+					case restartChan <- struct{}{}:
+					default:
+					}
 				}
 			case err, ok := <-watcher.Errors:
 				if !ok {

--- a/tanukiup/tanukiup_unix_test.go
+++ b/tanukiup/tanukiup_unix_test.go
@@ -1,0 +1,205 @@
+//go:build unix
+
+package tanukiup
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+const tanukiupHelperEnv = "TANUKIUP_TEST_HELPER_PROCESS"
+
+func TestRunRestartTerminatesDescendantProcesses(t *testing.T) {
+	t.Setenv(tanukiupHelperEnv, "1")
+
+	tempDir := t.TempDir()
+	watchDir := filepath.Join(tempDir, "watch")
+	if err := os.Mkdir(watchDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	watchFile := filepath.Join(watchDir, "main.go")
+	if err := os.WriteFile(watchFile, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pidFile := filepath.Join(tempDir, "grandchild.pid")
+	readyFile := filepath.Join(tempDir, "ready")
+	helperCommand := []string{
+		os.Args[0],
+		"-test.run=^TestTanukiupHelperProcess$",
+		"--",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- Run(ctx,
+			WithDirs([]string{watchDir}),
+			WithFileExts([]string{".go"}),
+			WithBuildCommand(append(slices.Clone(helperCommand), "build")),
+			WithExecCommand(append(slices.Clone(helperCommand), "parent", pidFile, readyFile)),
+			WithLogLevel(slog.LevelError),
+			WithTempDir(tempDir),
+		)
+	}()
+	defer func() {
+		cancel()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("tanukiup returned error: %v", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Errorf("tanukiup did not stop")
+		}
+	}()
+
+	waitForFile(t, readyFile, 5*time.Second)
+	oldPID := readPIDFile(t, pidFile)
+	defer killPID(oldPID)
+	if !pidExists(oldPID) {
+		t.Fatalf("grandchild process did not start: pid=%d", oldPID)
+	}
+
+	if err := os.Remove(readyFile); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.OpenFile(watchFile, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString("\n"); err != nil {
+		_ = f.Close()
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	waitForFile(t, readyFile, 5*time.Second)
+	newPID := readPIDFile(t, pidFile)
+	defer killPID(newPID)
+	if newPID == oldPID {
+		t.Fatalf("restart did not replace grandchild process: pid=%d", oldPID)
+	}
+
+	if stillRunning := waitForPIDExit(oldPID, 2*time.Second); stillRunning {
+		t.Fatalf("old descendant process is still running after restart: pid=%d", oldPID)
+	}
+}
+
+func TestTanukiupHelperProcess(t *testing.T) {
+	if os.Getenv(tanukiupHelperEnv) != "1" {
+		return
+	}
+	args := os.Args
+	idx := slices.Index(args, "--")
+	if idx == -1 || idx+1 >= len(args) {
+		fmt.Fprintln(os.Stderr, "missing helper mode")
+		os.Exit(2)
+	}
+
+	switch mode := args[idx+1]; mode {
+	case "build":
+		os.Exit(0)
+	case "parent":
+		if idx+3 >= len(args) {
+			fmt.Fprintln(os.Stderr, "missing parent helper args")
+			os.Exit(2)
+		}
+		runTanukiupParentHelper(args[idx+2], args[idx+3])
+	case "grandchild":
+		for {
+			time.Sleep(time.Hour)
+		}
+	default:
+		fmt.Fprintf(os.Stderr, "unknown helper mode: %s\n", mode)
+		os.Exit(2)
+	}
+}
+
+func runTanukiupParentHelper(pidFile, readyFile string) {
+	cmd := exec.Command(os.Args[0], "-test.run=^TestTanukiupHelperProcess$", "--", "grandchild")
+	cmd.Env = os.Environ()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to start grandchild: %v\n", err)
+		os.Exit(2)
+	}
+	if err := os.WriteFile(pidFile, []byte(strconv.Itoa(cmd.Process.Pid)), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to write pid file: %v\n", err)
+		os.Exit(2)
+	}
+	if err := os.WriteFile(readyFile, []byte("ready"), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to write ready file: %v\n", err)
+		os.Exit(2)
+	}
+	for {
+		time.Sleep(time.Hour)
+	}
+}
+
+func waitForFile(t *testing.T, path string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		} else if !errors.Is(err, os.ErrNotExist) {
+			t.Fatal(err)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", path)
+}
+
+func readPIDFile(t *testing.T, path string) int {
+	t.Helper()
+	bs, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(bs)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pid
+}
+
+func waitForPIDExit(pid int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if !pidExists(pid) {
+			return false
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return pidExists(pid)
+}
+
+func pidExists(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}
+
+func killPID(pid int) {
+	if pid <= 0 {
+		return
+	}
+	_ = syscall.Kill(pid, syscall.SIGKILL)
+}

--- a/tanukiup/tanukiup_unix_test.go
+++ b/tanukiup/tanukiup_unix_test.go
@@ -6,9 +6,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -105,6 +107,101 @@ func TestRunRestartTerminatesDescendantProcesses(t *testing.T) {
 	cleanupOldPID = false
 }
 
+func TestRunCancelWaitsForDescendantCleanup(t *testing.T) {
+	t.Setenv(tanukiupHelperEnv, "1")
+
+	tempDir := t.TempDir()
+	watchDir := filepath.Join(tempDir, "watch")
+	if err := os.Mkdir(watchDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	pidFile := filepath.Join(tempDir, "grandchild.pid")
+	readyFile := filepath.Join(tempDir, "ready")
+	helperCommand := []string{
+		os.Args[0],
+		"-test.run=^TestTanukiupHelperProcess$",
+		"--",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- Run(ctx,
+			WithDirs([]string{watchDir}),
+			WithBuildCommand(append(slices.Clone(helperCommand), "build")),
+			WithExecCommand(append(slices.Clone(helperCommand), "parent", pidFile, readyFile)),
+			WithLogLevel(slog.LevelError),
+			WithTempDir(tempDir),
+		)
+	}()
+
+	waitForFile(t, readyFile, 5*time.Second)
+	pid := readPIDFile(t, pidFile)
+	cleanupPID := true
+	defer func() {
+		if cleanupPID {
+			killPID(pid)
+		}
+	}()
+	if !pidExists(pid) {
+		t.Fatalf("grandchild process did not start: pid=%d", pid)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("tanukiup returned error: %v", err)
+		}
+	case <-time.After(6 * time.Second):
+		t.Fatal("tanukiup did not stop")
+	}
+	if pidExists(pid) {
+		t.Fatalf("descendant process is still running after Run returned: pid=%d", pid)
+	}
+	cleanupPID = false
+}
+
+func TestRunCommandGivesDescendantsShutdownGracePeriod(t *testing.T) {
+	t.Setenv(tanukiupHelperEnv, "1")
+
+	tempDir := t.TempDir()
+	terminatedFile := filepath.Join(tempDir, "terminated")
+	exitedFile := filepath.Join(tempDir, "exited")
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := newCommand(
+		os.Args[0],
+		"-test.run=^TestTanukiupHelperProcess$",
+		"--",
+		"parent-graceful-grandchild",
+		terminatedFile,
+		exitedFile,
+	)
+	cmd.Env = os.Environ()
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runCommand(ctx, cmd)
+	}()
+
+	waitForFile(t, terminatedFile, 5*time.Second)
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("runCommand returned error: %v", err)
+		}
+	case <-time.After(6 * time.Second):
+		t.Fatal("runCommand did not stop")
+	}
+	if _, err := os.Stat(exitedFile); err != nil {
+		t.Fatalf("grandchild did not exit gracefully: %v", err)
+	}
+}
+
 func TestTanukiupHelperProcess(t *testing.T) {
 	if os.Getenv(tanukiupHelperEnv) != "1" {
 		return
@@ -125,6 +222,18 @@ func TestTanukiupHelperProcess(t *testing.T) {
 			os.Exit(2)
 		}
 		runTanukiupParentHelper(args[idx+2], args[idx+3])
+	case "parent-graceful-grandchild":
+		if idx+3 >= len(args) {
+			fmt.Fprintln(os.Stderr, "missing parent-graceful-grandchild helper args")
+			os.Exit(2)
+		}
+		runTanukiupParentGracefulGrandchildHelper(args[idx+2], args[idx+3])
+	case "graceful-grandchild":
+		if idx+3 >= len(args) {
+			fmt.Fprintln(os.Stderr, "missing graceful-grandchild helper args")
+			os.Exit(2)
+		}
+		runTanukiupGracefulGrandchildHelper(args[idx+2], args[idx+3])
 	case "grandchild":
 		for {
 			time.Sleep(time.Hour)
@@ -158,6 +267,42 @@ func runTanukiupParentHelper(pidFile, readyFile string) {
 	for {
 		time.Sleep(time.Hour)
 	}
+}
+
+func runTanukiupParentGracefulGrandchildHelper(terminatedFile, exitedFile string) {
+	cmd := exec.Command(os.Args[0], "-test.run=^TestTanukiupHelperProcess$", "--", "graceful-grandchild", terminatedFile, exitedFile)
+	cmd.Env = os.Environ()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to start graceful grandchild: %v\n", err)
+		os.Exit(2)
+	}
+	go func() {
+		_ = cmd.Wait()
+	}()
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGTERM)
+	defer signal.Stop(sig)
+	<-sig
+	os.Exit(0)
+}
+
+func runTanukiupGracefulGrandchildHelper(terminatedFile, exitedFile string) {
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGTERM)
+	defer signal.Stop(sig)
+	if err := os.WriteFile(terminatedFile, []byte("ready"), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to write terminated file: %v\n", err)
+		os.Exit(2)
+	}
+	<-sig
+	time.Sleep(200 * time.Millisecond)
+	if err := os.WriteFile(exitedFile, []byte("exited"), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to write exited file: %v\n", err)
+		os.Exit(2)
+	}
+	os.Exit(0)
 }
 
 func waitForFile(t *testing.T, path string, timeout time.Duration) {

--- a/tanukiup/tanukiup_unix_test.go
+++ b/tanukiup/tanukiup_unix_test.go
@@ -67,7 +67,12 @@ func TestRunRestartTerminatesDescendantProcesses(t *testing.T) {
 
 	waitForFile(t, readyFile, 5*time.Second)
 	oldPID := readPIDFile(t, pidFile)
-	defer killPID(oldPID)
+	cleanupOldPID := true
+	defer func() {
+		if cleanupOldPID {
+			killPID(oldPID)
+		}
+	}()
 	if !pidExists(oldPID) {
 		t.Fatalf("grandchild process did not start: pid=%d", oldPID)
 	}
@@ -97,6 +102,7 @@ func TestRunRestartTerminatesDescendantProcesses(t *testing.T) {
 	if stillRunning := waitForPIDExit(oldPID, 2*time.Second); stillRunning {
 		t.Fatalf("old descendant process is still running after restart: pid=%d", oldPID)
 	}
+	cleanupOldPID = false
 }
 
 func TestTanukiupHelperProcess(t *testing.T) {
@@ -138,6 +144,9 @@ func runTanukiupParentHelper(pidFile, readyFile string) {
 		fmt.Fprintf(os.Stderr, "failed to start grandchild: %v\n", err)
 		os.Exit(2)
 	}
+	go func() {
+		_ = cmd.Wait()
+	}()
 	if err := os.WriteFile(pidFile, []byte(strconv.Itoa(cmd.Process.Pid)), 0o644); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to write pid file: %v\n", err)
 		os.Exit(2)


### PR DESCRIPTION
## Summary
  - add a regression test proving tanukiup restarts used to leave descendant processes behind
  - run tanukiup commands in their own process group on Unix
  - wait for the old process tree to stop before starting the next command

  ## Tests
  - go test ./...
  